### PR TITLE
ENV typo fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ ENV.mobileTouch = {
     //passed to new Hammer.Manager(element, options)
     options : {
        domEvents : true
-    }
+    },
     
     //passed to the respective recognizer
     tune : {
       tap : { time : 250, threshold : 9 }, //Hammer default is 250 / 2
       press : { time : 251, threshold : 9 }, //Hammer default is 500 / 5
-      swipe : { velocity : .3, threshold : 25 },
+      swipe : { velocity : 0.3, threshold : 25 },
       pan : {},
       pinch : {},
       rotate : {}


### PR DESCRIPTION
My JS linter caught this when starting to work with ember-mobiletouch. Figured this fix might prevent any confusing errors for anyone copy/pasting (like me). :)