### PR TITLE
Switch to relying on import for modifications to core ember classes rather than initializer

### DIFF
--- a/addon/mixins/hammer-events.js
+++ b/addon/mixins/hammer-events.js
@@ -70,7 +70,7 @@ var hammerEvents = {
     tune: {
       tap: { time : 250, threshold : 9 }, //Hammer default is 250 / 2
       press: { time : 251, threshold : 9 }, //Hammer default is 500 / 5
-      swipe: { velocity : .3, threshold : 25 },
+      swipe: { velocity : 0.3, threshold : 25 },
       pan: {},
       pinch: {},
       rotate: {}
@@ -146,9 +146,9 @@ export default Ember.Mixin.create({
       var $element = Ember.$(e.target);
       // cancel the click only if there is an ember action defined on the input or button of type submit
       var cancelIf =
-        ($element.is('a[href]') && !/^mailto:/.test($element.attr('href')))
-        || $element.is('button[type!="submit"], input[type="button"]')
-        || ($element.is('input[type="submit"], button[type="submit"]') && $element.attr('data-ember-action'));
+        ($element.is('a[href]') && !/^mailto:/.test($element.attr('href'))) ||
+          $element.is('button[type!="submit"], input[type="button"]') ||
+          ($element.is('input[type="submit"], button[type="submit"]') && $element.attr('data-ember-action'));
       if (cancelIf) {
         e.preventDefault();
         e.stopPropagation();

--- a/addon/utils/capitalize-word.js
+++ b/addon/utils/capitalize-word.js
@@ -1,3 +1,3 @@
 export default function (s) {
   return s.charAt(0).toUpperCase() + s.slice(1);
-};
+}

--- a/addon/utils/prevent-ghost-clicks.js
+++ b/addon/utils/prevent-ghost-clicks.js
@@ -1,3 +1,5 @@
+import Ember from "ember"; // Ember.run.bind
+
 /**
  * Prevent click events after a touchend.
  *

--- a/addon/utils/prevent-ghost-clicks.js
+++ b/addon/utils/prevent-ghost-clicks.js
@@ -82,14 +82,14 @@ function makeGhostBuster(window, document) {
    * @param {EventTarget} el
    */
   return {
-    add : function (el) {
+    add : Ember.run.bind(this, function (el) {
       el.addEventListener("touchstart", resetCoordinates, true);
       el.addEventListener("touchend", registerCoordinates, true);
-    }.bind(this),
-    remove : function (el) {
+    }),
+    remove : Ember.run.bind(this, function (el) {
       el.removeEventListener("touchstart", resetCoordinates);
       el.removeEventListener("touchend", registerCoordinates);
-    }.bind(this)
+    })
   };
 
 }

--- a/app/overrides/ember-mobiletouch.js
+++ b/app/overrides/ember-mobiletouch.js
@@ -1,40 +1,34 @@
 import Ember from 'ember'; //event dispatcher
 import config from '../config/environment'; //ENV.hammer
-import HammerEvents from 'ember-mobiletouch/mixins/hammer-events';
 import GesturesMixin from 'ember-mobiletouch/mixins/gestures';
 import LinkViewMods from 'ember-mobiletouch/mixins/link-view-mods';
+import HammerEvents from 'ember-mobiletouch/mixins/hammer-events';
 
 var USE_HTMLBARS = !!Ember.HTMLBars;
 
-export default {
+var overrides = function() {
+    var oldActionHelper;
+    var defaultTapOnPress = config.mobileTouch.defaultTapOnPress || true;
+    var mobileTouchConfig = { _mobileTouchConfig : config.mobileTouch || {} };
 
-  name: 'mobiletouch',
-
-  initialize: function(container) {
-
-    var dispatcher = Ember.EventDispatcher.extend({ _mobileTouchConfig : config.mobileTouch || {} }, HammerEvents),
-      defaultTapOnPress = config.mobileTouch.defaultTapOnPress || true,
-      oldActionHelper;
+    // modify the dispatcher
+    Ember.EventDispatcher.reopen(mobileTouchConfig);
+    Ember.EventDispatcher.reopen(HammerEvents);
 
     //components extend Ember.View, so this should be all that's needed
     Ember.View.reopen(GesturesMixin, {
       __useGesturesHash : config.mobileTouch ? config.mobileTouch.useGesturesHash : false
     });
-
     Ember.LinkView.reopen({ __defaultTapOnPress : defaultTapOnPress }, LinkViewMods);
 
     if (USE_HTMLBARS) {
-
       //cache the old handler
       oldActionHelper = Ember.Handlebars.helpers.action.helperFunction;
 
       Ember.Handlebars.helpers.action.helperFunction = function (params, hash, options, env) {
-
         hash.on = hash.on || 'tap';
         oldActionHelper.apply(this, arguments);
-
       };
-
     } else {
       oldActionHelper = Ember.Handlebars.helpers.action;
       Ember.Handlebars.helpers.action = function (/*actionName*/) {
@@ -44,8 +38,7 @@ export default {
         return oldActionHelper.apply(this, arguments);
       };
     }
-
-    container.register('event_dispatcher:main', dispatcher);
-
-  }
 };
+
+// overrides will be applied immediately and only once when the module is imported
+export default overrides();


### PR DESCRIPTION
Solves #10. Instead of using an initializer, this PR relies on import and directly reopens `Ember.EventDispatcher` rather than extend it. This approach has a number of advantages:

0. Unit tests made with `ember-cli` blueprints will have ember-mobiletouch functionality out of the box. 
0. It's guaranteed to only be executed once.

As it stands (before this PR) component unit tests (and other view unit tests) will not be able to test `ember-mobiletouch` functionality because the initializer is not run and the component is configured to use the built-in `Ember.EventDispatcher`. The initializer-based method could also fail to reveal problems in unit tests that are caused by use of `ember-mobiletouch`, i.e., the unit test passes using stock event handling behavior but in the live application the functionality is broken. 

I have moved the initializer code to:

    app/overrides/ember-mobiletouch.js

This requires placing the following line in app.js and test-helper.js:

    import mobileTouchOverrides from 'yourapp/overrides/ember-mobiletouch';

Perhaps these import statements could be added by the `ember install:addon` command? I'm not familiar enough with addons to know if this is possible. 