### PR TITLE
function.prototype.bind is not available in phantomjs

### DIFF
--- a/addon/utils/prevent-ghost-clicks.js
+++ b/addon/utils/prevent-ghost-clicks.js
@@ -1,3 +1,5 @@
+import Ember from "ember"; // Ember.run.bind
+
 /**
  * Prevent click events after a touchend.
  *
@@ -82,14 +84,14 @@ function makeGhostBuster(window, document) {
    * @param {EventTarget} el
    */
   return {
-    add : function (el) {
+    add : Ember.run.bind(this, function (el) {
       el.addEventListener("touchstart", resetCoordinates, true);
       el.addEventListener("touchend", registerCoordinates, true);
-    }.bind(this),
-    remove : function (el) {
+    }),
+    remove : Ember.run.bind(this, function (el) {
       el.removeEventListener("touchstart", resetCoordinates);
       el.removeEventListener("touchend", registerCoordinates);
-    }.bind(this)
+    })
   };
 
 }


### PR DESCRIPTION
Since function.prototype.bind is not available in phantomjs, it makes more sense to use Ember.run.bind, which provides mostly the same functionality. 