### PR TITLE
since we're using tap for link-to, kill clicks

### DIFF
--- a/addon/overrides/link-view.js
+++ b/addon/overrides/link-view.js
@@ -6,6 +6,10 @@ export default Ember.LinkView.reopen({
 
   __defaultTapOnPress : true,
 
+  click: function(event) {
+    event.preventDefault();
+  },
+
   init: function() {
 
     //run normal linkView setup


### PR DESCRIPTION
Fixes #14. 

Simply add a click handler to link-to that kills the click. This seemed easier than enhancing click busting or reworking bubbling.

There may be a more comprehensive way to do this, but this works for link-to elements. I'm not sure if there are any negative implications, but so far I haven't discovered any.