### PR TITLE
prevent links that have {{action}} handlers from triggering

### DIFF
--- a/addon/overrides/event-dispatcher.js
+++ b/addon/overrides/event-dispatcher.js
@@ -7,6 +7,7 @@ import defaultConfiguration from "../default-config";
 import hammerEvents from "../utils/hammer-events";
 import RecognizerInterface from "../recognizers";
 import removeEventsPatch from "../utils/determine-remove-events-patch";
+import jQuery from "jquery";
 
 var IS_MOBILE = !!("ontouchstart" in window);
 
@@ -231,6 +232,15 @@ export default Ember.EventDispatcher.reopen({
 
     //setup hammer
     this._initializeHammer(rootElement);
+
+    // TODO: Do we need to tear this down? We may also want to conditionally stop
+    // propagation, but I couldn't figure out how do do this because we don't seem
+    // to have access to the {{action}} helper options that were used to define it
+    // such as preventDefault and bubbles.
+    jQuery(rootElement).on('click.ember-mobiletouch', '[data-ember-action]', function(e) {
+      e.stopPropagation();
+      e.preventDefault();
+    });
 
     //setup rootElement and  event listeners
     this._super(addedEvents, rootElement);

--- a/tests/dummy/app/pods/actions/controller.js
+++ b/tests/dummy/app/pods/actions/controller.js
@@ -6,6 +6,9 @@ export default Ember.Controller.extend({
 
   actions : {
 
+    anotherAction : function() {
+    },
+
     genericAction : function () {
       this.transitionToRoute('test-successful');
     },

--- a/tests/dummy/app/pods/actions/template.hbs
+++ b/tests/dummy/app/pods/actions/template.hbs
@@ -9,3 +9,7 @@
 <div {{action "actionWithParams" foo on="swipeRight"}} id="specificGestureWithParams"></div>
 
 <a href="http://example.com/failure" {{action "genericAction"}} id="actionOnLink"><div class="internal-content"></div></a>
+
+{{#view 'has-handlers' id='containsBubblingAction'}}
+  <div {{action "anotherAction" bubble=true}} id="bubblingAction"></div>
+{{/view}}

--- a/tests/dummy/app/views/has-handlers.js
+++ b/tests/dummy/app/views/has-handlers.js
@@ -1,0 +1,22 @@
+import Ember from 'ember';
+
+export default Ember.View.extend({
+  clickEvidence: null,
+  tapEvidence: null,
+  internalClickEvidence: null,
+
+  reset: function() {
+    this.set('internalClickEvidence', 0);
+    this.set('clickEvidence', 0);
+    this.set('tapEvidence', 0);
+  }.on('init'),
+
+  internalClick: function() {
+    this.incrementProperty('internalClickEvidence');
+  },
+
+  tap: function() {
+    this.incrementProperty('tapEvidence');
+  }
+
+});

--- a/tests/unit/action-test.js
+++ b/tests/unit/action-test.js
@@ -109,10 +109,6 @@ test("If an action handler is on a link, a click on the link is discarded.", fun
 
 });
 
-/*
- * TODO: This needs to stay commented out until we fix it, becuase the test runner
- * redirects away and we can't see test results.
- *
 test("If an action handler is on a link, a click on a child element of the link is discarded.", function(assert) {
 
   assert.expect(1);
@@ -128,7 +124,6 @@ test("If an action handler is on a link, a click on a child element of the link 
   });
 
 });
-*/
 
 test("If an action handler is on a link, tap on the link calls the action.", function(assert) {
 
@@ -147,3 +142,35 @@ test("If an action handler is on a link, tap on the link calls the action.", fun
 
 });
 
+test("Tap allowed to bubble through action-bearing elements", function(assert) {
+
+  assert.expect(1);
+  visit('/actions');
+
+  andThen(function () {
+    triggerEvent('#bubblingAction', 'tap');
+  });
+
+  andThen(function() {
+    var view = Ember.View.views.containsBubblingAction;
+    assert.equal(view.get('tapEvidence'), 1, 'bubbled');
+  });
+
+});
+
+test("Click doesn't bubble through action-bearing elements", function(assert) {
+
+  assert.expect(2);
+  visit('/actions');
+
+  andThen(function () {
+    triggerEvent('#bubblingAction', 'click');
+  });
+
+  andThen(function() {
+    var view = Ember.View.views.containsBubblingAction;
+    assert.equal(view.get('internalClickEvidence'), 0, 'no internalClick');
+    assert.equal(view.get('tapEvidence'), 0, 'no tap');
+  });
+
+});


### PR DESCRIPTION
Add a click handler that filters based on `data-ember-action` labels so it just picks up `{{action}}` elements and kills clicks. Added a few specs to test that bubbling isn't disrupted for taps. 