### PR TITLE
fixes related to submit buttons

### DIFF
--- a/addon/overrides/event-dispatcher.js
+++ b/addon/overrides/event-dispatcher.js
@@ -255,10 +255,18 @@ export default Ember.EventDispatcher.reopen({
     // Tap events need to be converted to submit events on mobile. This is because the
     // click events that would ordinarily trigger default submit event get prevented
     // by the ghost click preventer.
-    $root.on('tap.ember-mobiletouch', 'button[type="submit"],input[type="submit"]', function() {
-      if (isMobile()) {
-        jQuery(this).trigger('submit');
-      }
+    var submitSelector = 'button[type="submit"],input[type="submit"]';
+    $root.on('tap.ember-mobiletouch', submitSelector, function() {
+      // When on mobile we get taps automatically and clicks are squashed,
+      // so we trigger submit on tap.
+      if (isMobile()) jQuery(this).trigger('submit');
+    });
+    $root.on('click.ember-mobiletouch', submitSelector, function() {
+      // When not on mobile we seem to get a click when enter is used to submit
+      // the form, so we rely on click to trigger submit. For actual button
+      // clicks we could rely on tap as in the mobile case, but this doen't work
+      // for pressing enter. 
+      if (!isMobile()) jQuery(this).trigger('submit');
     });
 
     // We may want to conditionally stop propagation, but I couldn't figure out
@@ -268,10 +276,7 @@ export default Ember.EventDispatcher.reopen({
       e.stopPropagation();
       // Allow clicks to trigger default behavor on form elements for which
       // actions are specified.
-      var allow = jQuery(this).is('form');
-      if (!allow) {
-        e.preventDefault();
-      }
+      e.preventDefault();
     });
 
     //setup rootElement and  event listeners

--- a/addon/overrides/event-dispatcher.js
+++ b/addon/overrides/event-dispatcher.js
@@ -259,14 +259,18 @@ export default Ember.EventDispatcher.reopen({
     $root.on('tap.ember-mobiletouch', submitSelector, function() {
       // When on mobile we get taps automatically and clicks are squashed,
       // so we trigger submit on tap.
-      if (isMobile()) jQuery(this).trigger('submit');
+      if (isMobile()) {
+        jQuery(this).trigger('submit');
+      }
     });
     $root.on('click.ember-mobiletouch', submitSelector, function() {
       // When not on mobile we seem to get a click when enter is used to submit
       // the form, so we rely on click to trigger submit. For actual button
       // clicks we could rely on tap as in the mobile case, but this doen't work
       // for pressing enter. 
-      if (!isMobile()) jQuery(this).trigger('submit');
+      if (!isMobile()) {
+        jQuery(this).trigger('submit');
+      }
     });
 
     // We may want to conditionally stop propagation, but I couldn't figure out

--- a/addon/utils/is-mobile.js
+++ b/addon/utils/is-mobile.js
@@ -1,0 +1,26 @@
+var IS_MOBILE;
+
+// Set our belief about whether the devise is mobile by inspecting ontouchstart
+var detectMobile = function() {
+  IS_MOBILE = !!("ontouchstart" in window);
+};
+
+// Return the current belief about whether the browser is mobile.
+var isMobile = function() {
+  return IS_MOBILE;
+};
+
+// This will generally only be done in tests.
+var fakeMobile = function(value) {
+  IS_MOBILE = value;
+};
+
+// Set the initial value of IS_MOBILE so that calls to isMobile will have
+// the correct value.
+detectMobile();
+
+export {
+  detectMobile,
+  isMobile,
+  fakeMobile
+};

--- a/addon/utils/prevent-ghost-clicks.js
+++ b/addon/utils/prevent-ghost-clicks.js
@@ -1,4 +1,5 @@
 import Ember from "ember"; // Ember.run.bind
+import { isMobile } from "./is-mobile";
 
 /**
  * Prevent click events after a touchend.
@@ -24,7 +25,7 @@ function makeGhostBuster(window, document) {
   var timeout = 2500;
 
   // no touch support
-  if(!("ontouchstart" in window)) {
+  if(!isMobile()) {
     return { add : function(){}, remove : function(){} };
   }
 

--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -21,7 +21,8 @@
     "andThen",
     "currentURL",
     "currentPath",
-    "currentRouteName"
+    "currentRouteName",
+    "getController"
   ],
   "node": false,
   "browser": false,

--- a/tests/dummy/app/pods/forms/controller.js
+++ b/tests/dummy/app/pods/forms/controller.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  submitEvidence: null,
+
+  reset: function() {
+    this.set('submitEvidence', 0);
+  }.on('init'),
+
+  actions: {
+    submitForm: function() {
+      this.incrementProperty('submitEvidence');
+    }
+  }
+});

--- a/tests/dummy/app/pods/forms/template.hbs
+++ b/tests/dummy/app/pods/forms/template.hbs
@@ -1,0 +1,4 @@
+<h3>Form with submit action</h3>
+<form id='form-with-submit-action' {{action "submitForm" on="submit"}}>
+  <button type="submit" id='submit-button-1'>Submit</button>
+</form>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -12,6 +12,7 @@ Router.map(function() {
   this.route('links');
   this.route('inputs');
   this.route('buttons');
+  this.route('forms');
 });
 
 export default Router;

--- a/tests/helpers/custom-helpers.js
+++ b/tests/helpers/custom-helpers.js
@@ -1,0 +1,10 @@
+import Ember from "ember";
+
+export default (function() {
+
+  Ember.Test.registerHelper('getController', function(app, controller, context) {
+    Ember.assert('helper must be given a controller name', !!controller);
+    return app.__container__.lookup("controller:"+controller);
+  });
+
+})();

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,17 +2,15 @@ import Ember from 'ember';
 import Application from '../../app';
 import Router from '../../router';
 import config from '../../config/environment';
+import customHelpers from './custom-helpers';
 
 import EventDispatcher from "ember-mobiletouch/overrides/event-dispatcher";
 import CustomRecognizers from "../../recognizers";
-
 
 EventDispatcher.reopen({
   _mobileTouchCustomizations : config,
   _customRecognizers : CustomRecognizers
 });
-
-
 
 export default function startApp(attrs) {
   var application;

--- a/tests/unit/forms-test.js
+++ b/tests/unit/forms-test.js
@@ -1,0 +1,74 @@
+import Ember from "ember";
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+import { isMobile, fakeMobile, detectMobile } from "ember-mobiletouch/utils/is-mobile";
+var App;
+
+module('Form Integration Tests - faking non-mobile', {
+
+  beforeEach: function() {
+    fakeMobile(false);
+    App = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(App, App.destroy);
+    detectMobile();
+  }
+
+ });
+
+test("Clicking button triggers default form action", function(assert) {
+  assert.expect(2);
+
+  var formsController = getController('forms');
+  formsController.reset();
+
+  visit('/forms');
+
+  andThen(function() {
+    assert.equal(formsController.get('submitEvidence'), 0);
+  });
+
+  triggerEvent('#submit-button-1', 'click');
+
+  andThen(function() {
+    assert.equal(formsController.get('submitEvidence'), 1);
+  });
+
+});
+
+module('Form Integration Tests - faking mobile', {
+
+  beforeEach: function() {
+    fakeMobile(true);
+    App = startApp();
+  },
+
+  afterEach: function() {
+    Ember.run(App, App.destroy);
+    detectMobile();
+  }
+
+ });
+
+test("Receiving tap on a button triggers default form action", function(assert) {
+  assert.expect(2);
+
+  var formsController = getController('forms');
+  formsController.reset();
+
+  visit('/forms');
+
+  andThen(function() {
+    assert.equal(formsController.get('submitEvidence'), 0);
+  });
+
+  triggerEvent('#submit-button-1', 'tap');
+
+  andThen(function() {
+    assert.equal(formsController.get('submitEvidence'), 1);
+  });
+
+});
+


### PR DESCRIPTION
Handling submit buttons is tricky.

On mobile we can trigger submit when we get a tap on a button. This largely works on non-mobile too, but it fails when `enter` is used to submit the form. At least on Chrome, this triggers a click on the default submit button, and we can use this to trigger a submit, which will get picked up the any `{{action on="submit"}}` handler there might be on the form.

Allow faking `IS_MOBILE` for testing purposes with explicit tests for mobile and non-mobile submit button behavior. 

It turns out phantomjs thinks it's a mobile phone and Chrome on my macbook does not. This is helpful because discrepancies between tests can sometimes be attributable to our attempt to handle events differently in the mobile/non-mobile cases. But to allow for explicit testing of both and getting both Chrome and phantomjs test to reliably pass, I added `fakeMoble(boolean)` to artifically set `IS_MOBILE` and `detectMobile` to restore it to whatever the browser detects as.

Added cleanup for the extra `.ember-mobiletouch` events were adding; this is important in tests.