### PR TITLE
Fix for users environment config not applying

### DIFF
--- a/app/overrides/ember-mobiletouch.js
+++ b/app/overrides/ember-mobiletouch.js
@@ -4,6 +4,6 @@ import CustomRecognizers from "../recognizers";
 
 
 export default EventDispatcher.reopen({
-  _mobileTouchCustomizations : config,
+  _mobileTouchCustomizations : config.mobileTouch,
   _customRecognizers : CustomRecognizers
 });

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -8,7 +8,7 @@ import CustomRecognizers from "../../recognizers";
 
 
 EventDispatcher.reopen({
-  _mobileTouchCustomizations : config,
+  _mobileTouchCustomizations : config.mobileTouch,
   _customRecognizers : CustomRecognizers
 });
 


### PR DESCRIPTION
Not sure if this is the best way to fix it.  But I determined that the problem with the config merging was that the merge function in the event-dispatcher was getting the full config from the user.  Not just the mobileTouch section of the config.

Obviously there are other ways to fix this.  Hopefully you find this fix adequate.  I didn't have time to setup the whole project run the tests.  I have confirmed that this change does fix it in the project I'm using it for.