### PR TITLE
built general mechanism to run pairs of tests

### DIFF
--- a/tests/.jshintrc
+++ b/tests/.jshintrc
@@ -22,7 +22,8 @@
     "currentURL",
     "currentPath",
     "currentRouteName",
-    "getController"
+    "getController",
+    "triggerTap"
   ],
   "node": false,
   "browser": false,

--- a/tests/dummy/app/pods/inputs/controller.js
+++ b/tests/dummy/app/pods/inputs/controller.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  name: 'inputs controller',
+  checkboxChecked: false
+});

--- a/tests/dummy/app/pods/inputs/template.hbs
+++ b/tests/dummy/app/pods/inputs/template.hbs
@@ -1,1 +1,3 @@
 {{view "input-test" id="focusTest"}}
+
+{{input id="checkboxTest" type="checkbox" checked=checkboxChecked}}

--- a/tests/helpers/custom-helpers.js
+++ b/tests/helpers/custom-helpers.js
@@ -1,12 +1,18 @@
 import Ember from "ember";
+import tap from './tap';
 
 export default (function() {
 
-  Ember.Test.registerHelper('getController',
-    function (app, name) {
-      Ember.assert('helper must be given a controller name', !!name);
-      return app.__container__.lookup('controller:' + name);
-    }
-  );
+  Ember.Test.registerHelper('getController', function (app, name) {
+    Ember.assert('helper must be given a controller name', !!name);
+    return app.__container__.lookup('controller:' + name);
+  });
+
+  // Send a tap or a click depending on if we think we're mobile or not.
+  Ember.Test.registerAsyncHelper('triggerTap', function(app, selector) {
+    Ember.assert('helper must be given a selector', !!selector);
+    tap(selector);
+    return app.testHelpers.wait();
+  });
 
 })();

--- a/tests/helpers/desktop-tap.js
+++ b/tests/helpers/desktop-tap.js
@@ -36,5 +36,4 @@ export default function desktopTap(selector) {
 
   });
 
-
 }

--- a/tests/helpers/pair.js
+++ b/tests/helpers/pair.js
@@ -1,0 +1,70 @@
+import { module, test } from 'qunit';
+import mobileDetection from "ember-mobiletouch/utils/is-mobile";
+
+var currentModuleLabel = null;
+var currentModuleHooks = null;
+var currentTests = [];
+
+// Save the label and hooks so we can use them with each pair of tests.
+var pairModule = function(label, hooks) {
+  currentModuleLabel = label;
+  currentModuleHooks = hooks;
+};
+
+// Save the tests so we can instantiate each test with each module in the pair.
+var pairTest = function(label, callback) {
+  currentTests.push([label, callback]);
+};
+
+// This function is necessary to trigger the tests to be instantiated. We need
+// to instantiate all the tests with one module and then all the tests with the
+// second module. Without a function to conclude the batch, we won't know when
+// the tests are done being defined.
+var pairConclude = function() {
+  if (!currentModuleLabel) {
+    throw "Missing module";
+  }
+
+  var hooks = currentModuleHooks || {};
+  var label = currentModuleLabel;
+  var origBeforeEach = hooks.beforeEach;
+  var origAfterEach = hooks.afterEach;
+
+  // Build a module for when IS_MOBILE is true and one for when it's false
+  [true,false].forEach(function(isMobile) {
+
+    // Make a new beforeEach and afterEach function.
+    hooks.beforeEach = function() {
+      mobileDetection.fake(isMobile);
+      if (!!origBeforeEach) {
+        origBeforeEach.call({});
+      }
+    };
+    hooks.afterEach = function() {
+      if (!!origAfterEach) {
+        origAfterEach.call({});
+      }
+      mobileDetection.detect();
+    };
+
+    // Instantiate a module with these updated hooks.
+    var desc = isMobile ? "(mobile)" : "(desktop)";
+    var fullLabel = label + " " + desc;
+    module(fullLabel, hooks);
+
+    // Instantiate one of each test for this module.
+    currentTests.forEach(function(labelCallbackTuple) {
+      var label = labelCallbackTuple[0];
+      var callback = labelCallbackTuple[1];
+      test(label, callback);
+    });
+
+  });
+
+  // Cleanup.
+  currentModuleLabel = null;
+  currentModuleHooks = null;
+  currentTests = [];
+};
+
+export { pairTest, pairModule, pairConclude };

--- a/tests/helpers/tap.js
+++ b/tests/helpers/tap.js
@@ -1,0 +1,12 @@
+import desktopTap from './desktop-tap';
+import mobileTap from './mobile-tap';
+import mobileDetection from "ember-mobiletouch/utils/is-mobile";
+
+// Tap using the event appropriate to the current IS_MOBILE value
+export default function tap(selector) {
+  if (mobileDetection.is()) {
+    return mobileTap(selector);
+  } else {
+    return desktopTap(selector);
+  }
+}

--- a/tests/integration/input-test.js
+++ b/tests/integration/input-test.js
@@ -1,110 +1,78 @@
 import Ember from "ember";
 import { module, test } from 'qunit';
+import { pairModule, pairTest, pairConclude } from '../helpers/pair';
 
 import mobileDetection from "ember-mobiletouch/utils/is-mobile";
 import startApp from '../helpers/start-app';
-import mobileTap from '../helpers/mobile-tap';
-import desktopTap from '../helpers/desktop-tap';
 
 var App;
 
-module('Input Focus Integration Tests (mobile)', {
+pairModule('Input Focus Integration Tests', {
 
   beforeEach: function() {
-    mobileDetection.fake(true);
     App = startApp();
   },
 
   afterEach: function() {
     Ember.run(App, App.destroy);
-    mobileDetection.detect();
   }
 
 });
 
 
+pairTest("Tap on inputs focus them.", function(assert) {
 
-test("Taps on inputs focus them.", function(assert) {
-
-  assert.expect(9);
-
-  visit('/inputs');
-
-  andThen(function () {
-
-    var view = Ember.View.views.focusTest;
-    var $element = view.$();
-
-    assert.notEqual(document.activeElement, $element.get(0), 'The input is not initially focused.');
-
-    mobileTap('#focusTest');
-    andThen(function() {
-
-      assert.equal(view.taps, 1, 'a tap was registered');
-      assert.equal(document.activeElement,$element.get(0), 'The input receives focus.');
-      assert.equal(view.focuses, 1, 'The view has been focused once.');
-
-      Ember.run.later(function () {
-        assert.equal(view.fastClicks, 0, 'a fastclick was not observed');
-        assert.equal(view.internalClicks, 0, 'the regular click was not observed');
-        assert.equal(view.clicks, 1, 'a single click was observed');
-        assert.equal(document.activeElement, $element.get(0), 'The input maintains focus.');
-        assert.equal(view.focuses, 1, 'The view has not been focused more than once.');
-      }, 350);
-
-    });
-  });
-
-});
-
-
-
-module('Input Focus Integration Tests (desktop)', {
-
-  beforeEach: function() {
-    mobileDetection.fake(false);
-    App = startApp();
-  },
-
-  afterEach: function() {
-    Ember.run(App, App.destroy);
-    mobileDetection.detect();
-  }
-
-});
-
-test("A click on an input generates focus.", function(assert) {
+  var view;
+  var $element;
 
   assert.expect(9);
 
   visit('/inputs');
 
-  andThen(function () {
+  andThen(function() {
 
-    var view = Ember.View.views.focusTest;
-    var $element = view.$();
+    view = Ember.View.views.focusTest;
+    $element = view.$();
 
     assert.notEqual(document.activeElement, $element.get(0), 'The input is not initially focused.');
-
-    desktopTap('#focusTest');
-
-    andThen(function() {
-
-      assert.equal(view.taps, 1, 'a tap was registered');
-      assert.equal(document.activeElement, $element.get(0), 'The input received focus.');
-      assert.equal(view.focuses, 1, 'The view has been focused once.');
-
-      Ember.run.later(function () {
-        assert.equal(view.fastClicks, 0, 'a fastclick was not observed');
-        assert.equal(view.internalClicks, 1, 'a regular click was observed');
-        assert.equal(view.clicks, 1, 'a single click was observed');
-        assert.equal(document.activeElement, $element.get(0), 'The input maintains focus.');
-        assert.equal(view.focuses, 1, 'The view has not been focused more than once.');
-      }, 350);
-
-    });
   });
 
+  triggerTap('#focusTest');
+
+  andThen(function() {
+
+    assert.ok(1);
+    assert.equal(view.get('taps'), 1, 'a tap was registered');
+    assert.equal(document.activeElement,$element.get(0), 'The input receives focus.');
+    assert.equal(view.focuses, 1, 'The view has been focused once.');
+
+    Ember.run.later(function () {
+      assert.equal(view.fastClicks, 0, 'a fastclick was not observed');
+      assert.equal(view.clicks, 1, 'a single click was observed');
+      assert.equal(document.activeElement, $element.get(0), 'The input maintains focus.');
+      assert.equal(view.focuses, 1, 'The view has not been focused more than once.');
+    }, 350);
+
+  });
 
 });
 
+
+pairTest("Tap on a checkbox causes it to be checked", function(assert) {
+
+  assert.expect(3);
+  var controller = getController('inputs');
+
+  assert.equal(controller.get('name'), 'inputs controller');
+  assert.ok(controller.get('checkboxChecked') === false);
+
+  visit('/inputs');
+  triggerTap('#checkboxTest');
+
+  andThen(function() {
+    assert.ok(controller.get('checkboxChecked'));
+  });
+
+});
+
+pairConclude();


### PR DESCRIPTION
I built a mechanism that allows one to write one module and set of tests, but it actually runs instantiates two modules and two sets of identical tests, with the difference being that one simulates mobile and one simulates desktop.

This saves from duplicating code, which I think will become very hard to maintain. It also forces us to write the tests in a way that doesn't tailor too much to mobile or desktop. 

The one klugey bit about it is the `pairConclude()` method that is needed to indicate that one is done with writing paired tests for this module. There's a comment in the code that describes more why this was necessary.

Either before a `pairModule` or after `pairConclude()` one can have regular modules and tests if it's necessary to somehow specifically test mobile or desktop, or if the tests are agnostic and we don't want to explicitly simulate both.

If you like this mechanism, we could convert the other tests that exist in duplicate to this mechanism.

As a side note, I've noticed some weird non-independence between test runs. Sometimes I need to kill the test runners and restart it and suddenly everything starts working...I think there's some state leakage or something... I don't think these problems are related to the changes in this PR, but if you think otherwise, perhaps I could try and track them down...the problem is it's very hard to reproduce.