### PR TITLE
Fixed installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,17 @@ Ember addon for touch and gesture support in ember based mobile apps and website
 
 ##Installation
 
-`npm install ember-mobiletouch`
+If you are a recent version of `ember-cli` (0.1.5 or later) do the following:
 
-`ember g ember-mobiletouch`
+    ember install:addon ember-cli-fastclick
+    ember install:addon ember-mobiletouch
 
-(or, as of recent changes)
 
-`ember install:addon ember-mobiletouch`
+or, if you have an old version of `ember-cli` you can do:
 
+    npm install ember-mobiletouch
+    ember g ember-mobiletouch
+    ember g ember-cli-fastclick
 
 ##What's Included
 

--- a/blueprints/ember-mobiletouch/index.js
+++ b/blueprints/ember-mobiletouch/index.js
@@ -5,22 +5,14 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    var success = true,
-      bowerPackages = [
+    var bowerPackages = [
         { name : 'hammerjs', version : '2.0.4' }
-      ],
-      npmPackages = [
-        {name : 'ember-cli-fastclick', version : '1.0.3'}
-      ];
+    ];
 
-    success = this.addBowerPackagesToProject(bowerPackages);
-
-    if (success) {
-      success = this.addPackagesToProject(npmPackages);
-    }
-
-    return success;
-
+    var receiver = this;
+    return this.addBowerPackagesToProject(bowerPackages).then(function() {
+      return receiver.addPackageToProject('ember-cli-fastclick');
+    });
   }
 
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-mobiletouch",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "dependencies": {
     "jquery": "^1.11.1",
     "ember": "1.10.0",
@@ -15,6 +15,6 @@
     "qunit": "~1.17.1"
   },
   "devDependencies": {
-    "hammerjs": "~2.0.4"
+    "hammerjs": "hammerjs/hammer.js#2.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-mobiletouch",
-  "version": "1.4.8",
+  "version": "1.4.10",
   "directories": {
     "doc": "doc",
     "test": "tests"


### PR DESCRIPTION
I needed to fix installation. It was broken because `addBowerPackagesToProject` and `addPackagesToProject` return thenables, and so both installs will only get run if they are chained. It seems there's now way to have  `ember-mobiletouch` automatically run the addon blueprint installer for  `ember-cli-fastclick`, so this must be an additional step. I have updated the `README` accordingly.

The order of the install commands when not using `ember install:addon` is significant. `ember g ember-mobiletouch` is installing the npm package `ember-cli-fastclick` so this must be run before `ember g ember-cli-fastclick`. (Alternatively, one could just `npm install ember-cli-fastclick` and not rely on the `ember-mobiletouch` blueprint to do the job).   

[See ember-cli issue 3418 ](https://github.com/ember-cli/ember-cli/issues/3418)