### PR TITLE
Fix testing historesis

### DIFF
--- a/addon/overrides/event-dispatcher.js
+++ b/addon/overrides/event-dispatcher.js
@@ -129,13 +129,12 @@ export default Ember.EventDispatcher.reopen({
     });
 
 
-    /*
-        Implements fastclick and fastfocus mechanisms on mobile web/Cordova
-     */
-    if (mobileDetection.is()) {
 
-      $root.on('tap.ember-mobiletouch press.ember-mobiletouch', function (e) {
-
+    $root.on('tap.ember-mobiletouch press.ember-mobiletouch', function (e) {
+      /*
+          Implements fastclick and fastfocus mechanisms on mobile web/Cordova
+       */
+      if (mobileDetection.is()) {
         var $element = Ember.$(e.currentTarget);
         var $target = Ember.$(e.target);
 
@@ -167,9 +166,9 @@ export default Ember.EventDispatcher.reopen({
           $target.trigger(click);
         }
 
-      });
+      }
 
-    }
+    });
 
   },
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,0 @@
-<h2 id="title">Welcome to Ember.js</h2>
-
-{{outlet}}


### PR DESCRIPTION
I believe I have fixed the problem I mentioned whereby tests would fail the second time they were run (but only in Chrome). This seems to have been a result of defining the handler only once based on the initially detected value of `IS_MOBILE`. 

The drawback of my fix is that even when `IS_MOBILE` is false, an event listener will still be created, it just won't do anything. And since this only affects testing, it's unfortunate. But I think the tradeoff is well worth it, because it's important for the general quality of this project for testing to be reliable and easy.