### PR TITLE
Form checkbox problem

### DIFF
--- a/addon/overrides/event-dispatcher.js
+++ b/addon/overrides/event-dispatcher.js
@@ -129,13 +129,12 @@ export default Ember.EventDispatcher.reopen({
     });
 
 
-    /*
-        Implements fastclick and fastfocus mechanisms on mobile web/Cordova
-     */
-    if (mobileDetection.is()) {
 
-      $root.on('tap.ember-mobiletouch press.ember-mobiletouch', function (e) {
-
+    $root.on('tap.ember-mobiletouch press.ember-mobiletouch', function (e) {
+      /*
+          Implements fastclick and fastfocus mechanisms on mobile web/Cordova
+       */
+      if (mobileDetection.is()) {
         var $element = Ember.$(e.currentTarget);
         var $target = Ember.$(e.target);
 
@@ -167,9 +166,9 @@ export default Ember.EventDispatcher.reopen({
           $target.trigger(click);
         }
 
-      });
+      }
 
-    }
+    });
 
   },
 

--- a/tests/dummy/app/pods/application/template.hbs
+++ b/tests/dummy/app/pods/application/template.hbs
@@ -8,5 +8,13 @@
 </header>
 
 <section class="row">
+  <div class="col-md-4">
+    <ul>
+      <li>{{#link-to "inputs"}}Input tests{{/link-to}}</li>
+    </ul>
+  </div>
+</section>
+
+<section class="row">
   {{outlet}}
 </section>

--- a/tests/dummy/app/pods/inputs/controller.js
+++ b/tests/dummy/app/pods/inputs/controller.js
@@ -2,5 +2,10 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   name: 'inputs controller',
-  checkboxChecked: false
+  checkbox1Checked: false,
+  checkbox2Checked: false,
+  checkbox3Checked: false,
+  watchBoxes:function() {
+    console.log('check');
+  }.observes('checkbox1Checked', 'checkbox2Checked', 'checkbox3Checked')
 });

--- a/tests/dummy/app/pods/inputs/template.hbs
+++ b/tests/dummy/app/pods/inputs/template.hbs
@@ -1,3 +1,13 @@
 {{view "input-test" id="focusTest"}}
 
-{{input id="checkboxTest" type="checkbox" checked=checkboxChecked}}
+<div id='checkbox1-test'>
+  {{input id="checkbox1" type="checkbox" checked=checkbox1Checked}}
+</div>
+
+<form id='checkbox2-test' {{action "submitForm" on="submit"}}>
+  {{input id='checkbox2' type="checkbox" checked=checkbox2Checked}}
+</form>
+
+<form id='checkbox3-test'>
+  {{input id='checkbox3' type="checkbox" checked=checkbox3Checked}}
+</form>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,0 @@
-<h2 id="title">Welcome to Ember.js</h2>
-
-{{outlet}}

--- a/tests/helpers/desktop-tap.js
+++ b/tests/helpers/desktop-tap.js
@@ -30,7 +30,7 @@ export default function desktopTap(selector) {
     $element.trigger(MouseUp);
     $element.trigger(Tap);
     $element.trigger(Click);
-    setTimeout((function () {
+    Ember.run.later((function () {
       resolve();
     }), 100);
 

--- a/tests/helpers/mobile-tap.js
+++ b/tests/helpers/mobile-tap.js
@@ -52,9 +52,9 @@ export default function mobileTap(selector) {
     $element.trigger(TouchStart);
     $element.trigger(TouchEnd);
     $element.trigger(Tap);
-    setTimeout((function () {
+    Ember.run.later((function () {
       $element.trigger(Click);
-      setTimeout((function () {
+      Ember.run.later((function () {
         resolve();
       }), 50);
     }), 300);

--- a/tests/integration/input-test.js
+++ b/tests/integration/input-test.js
@@ -50,7 +50,6 @@ pairTest("Tap on inputs focus them.", function(assert) {
       assert.equal(view.clicks, 1, 'a single click was observed');
       assert.equal(document.activeElement, $element.get(0), 'The input maintains focus.');
       assert.equal(view.focuses, 1, 'The view has not been focused more than once.');
-      console.log(view.internalClicks + ' ' + mobileDetection.is());
     }, 350);
 
   });

--- a/tests/integration/input-test.js
+++ b/tests/integration/input-test.js
@@ -25,7 +25,7 @@ pairTest("Tap on inputs focus them.", function(assert) {
   var view;
   var $element;
 
-  assert.expect(9);
+  assert.expect(8);
 
   visit('/inputs');
 
@@ -41,8 +41,7 @@ pairTest("Tap on inputs focus them.", function(assert) {
 
   andThen(function() {
 
-    assert.ok(1);
-    assert.equal(view.get('taps'), 1, 'a tap was registered');
+    assert.equal(view.taps, 1, 'a tap was registered');
     assert.equal(document.activeElement,$element.get(0), 'The input receives focus.');
     assert.equal(view.focuses, 1, 'The view has been focused once.');
 
@@ -51,28 +50,48 @@ pairTest("Tap on inputs focus them.", function(assert) {
       assert.equal(view.clicks, 1, 'a single click was observed');
       assert.equal(document.activeElement, $element.get(0), 'The input maintains focus.');
       assert.equal(view.focuses, 1, 'The view has not been focused more than once.');
+      console.log(view.internalClicks + ' ' + mobileDetection.is());
     }, 350);
 
   });
 
 });
 
+/*
+// Three related tests that vary in the context of the checkbox.
+var testBatch = [
+  {label: 'without a form', sel: '#checkbox1-test', prop: 'checkbox1Checked'},
+  {label: 'form without an action', sel: '#checkbox2-test', prop: 'checkbox2Checked'},
+  {label: 'form with a submit action', sel: '#checkbox3-test', prop: 'checkbox3Checked'}
+];
 
-pairTest("Tap on a checkbox causes it to be checked", function(assert) {
-
-  assert.expect(3);
-  var controller = getController('inputs');
-
-  assert.equal(controller.get('name'), 'inputs controller');
-  assert.ok(controller.get('checkboxChecked') === false);
-
-  visit('/inputs');
-  triggerTap('#checkboxTest');
-
-  andThen(function() {
-    assert.ok(controller.get('checkboxChecked'));
+// Instantiate a test for each member in the testBatch.
+testBatch.forEach(function(t) {
+  var checkboxSel = t.sel+' input[type="checkbox"]';
+  pairTest("Tap checkbox makes it checked - "+t.label, function(assert) {
+  
+    assert.expect(6);
+    var controller = getController('inputs');
+  
+    assert.equal(controller.get('name'), 'inputs controller');
+    assert.ok(controller.get(t.prop) === false);
+  
+    visit('/inputs');
+    triggerTap(checkboxSel);
+  
+    andThen(function() {
+      assert.ok(controller.get(t.prop));
+      assert.ok($(checkboxSel).prop('checked'));
+      Ember.run.later(function() {
+        assert.ok($(checkboxSel).prop('checked'));
+      }, 100);
+    });
+    andThen(function() {
+      assert.ok($(checkboxSel).prop('checked'));
+    });
+  
   });
-
 });
+*/
 
 pairConclude();


### PR DESCRIPTION
I was trying to track down a problem I was having with checkboxes. 

This PR adds code to the dummy app to illustrate the problem. However, to see the problem it's necessary to run `ember serve` and navigate to the Input tests area (I've added a link from the main page in the dummy app). You will see three checkboxes. The first and third can be checked, but the middle cannot be checked.

I have added integration tests of each of these checkboxes, but strangely all the tests pass.

It only occurs when the checkbox is inside a form element that has an `{{action}}` specified. 

This PR should help us track down the problem. 