### PR TITLE
Removed use of function prototype extensions and Ember.keys

### DIFF
--- a/addon/mixins/pinch.js
+++ b/addon/mixins/pinch.js
@@ -23,7 +23,7 @@ export default Ember.Mixin.create({
   _hammerOptions : null,
 
 
-  __setupHammer : function () {
+  __setupHammer : Ember.on('didInsertElement', function () {
 
     var element = this.$()[0];
     var instance = this.get('_hammerInstance');
@@ -48,18 +48,18 @@ export default Ember.Mixin.create({
 
     }
 
-  }.on('didInsertElement'),
+  }),
 
 
   /**!
    * Destroy the localized instance when the view/component is destroyed
    */
-  __teardownHammer : function () {
+  __teardownHammer : Ember.on('willDestroyElement', function () {
     var hammer = this.get('_hammerInstance');
     if (hammer) {
       hammer.destroy();
       this.set('_hammerInstance', null);
     }
-  }.on('willDestroyElement')
+  })
 
 });

--- a/addon/mixins/rotate.js
+++ b/addon/mixins/rotate.js
@@ -23,7 +23,7 @@ export default Ember.Mixin.create({
   _hammerOptions : null,
 
 
-  __setupHammer : function () {
+  __setupHammer : Ember.on('didInsertElement', function () {
 
     var element = this.$()[0];
     var instance = this.get('_hammerInstance');
@@ -48,18 +48,18 @@ export default Ember.Mixin.create({
 
     }
 
-  }.on('didInsertElement'),
+  }),
 
 
   /**!
    * Destroy the localized instance when the view/component is destroyed
    */
-  __teardownHammer : function () {
+  __teardownHammer : Ember.on('willDestroyElement', function () {
     var hammer = this.get('_hammerInstance');
     if (hammer) {
       hammer.destroy();
       this.set('_hammerInstance', null);
     }
-  }.on('willDestroyElement')
+  })
 
 });

--- a/addon/mixins/vertical-pan.js
+++ b/addon/mixins/vertical-pan.js
@@ -44,7 +44,7 @@ export default Ember.Mixin.create({
    * }
    * ```
    */
-  __setupHammer : function () {
+  __setupHammer : Ember.on('didInsertElement', function () {
 
     var element = this.$()[0];
     var instance = this.get('_hammerInstance');
@@ -79,18 +79,18 @@ export default Ember.Mixin.create({
 
     }
 
-  }.on('didInsertElement'),
+  }),
 
 
   /**!
    * Destroy the localized instance when the view/component is destroyed
    */
-  __teardownHammer : function () {
+  __teardownHammer : Ember.on('willDestroyElement', function () {
     var hammer = this.get('_hammerInstance');
     if (hammer) {
       hammer.destroy();
       this.set('_hammerInstance', null);
     }
-  }.on('willDestroyElement')
+  })
 
 });

--- a/addon/mixins/vertical-swipe.js
+++ b/addon/mixins/vertical-swipe.js
@@ -44,7 +44,7 @@ export default Ember.Mixin.create({
    * }
    * ```
    */
-  __setupHammer : function () {
+  __setupHammer : Ember.on('didInsertElement', function () {
 
     var element = this.$()[0];
     var instance = this.get('_hammerInstance');
@@ -79,18 +79,18 @@ export default Ember.Mixin.create({
 
     }
 
-  }.on('didInsertElement'),
+  }),
 
 
   /**!
    * Destroy the localized instance when the view/component is destroyed
    */
-  __teardownHammer : function () {
+  __teardownHammer : Ember.on('willDestroyElement', function () {
     var hammer = this.get('_hammerInstance');
     if (hammer) {
       hammer.destroy();
       this.set('_hammerInstance', null);
     }
-  }.on('willDestroyElement')
+  })
 
 });

--- a/addon/overrides/mobiletouch-mixin.js
+++ b/addon/overrides/mobiletouch-mixin.js
@@ -61,7 +61,7 @@ export default Ember.Mixin.create({
   /**!
    *
    */
-  __setupGestures : function () {
+  __setupGestures : Ember.on('init', function () {
 
     var EventManager = this.get('eventManager') || this;
     var events;
@@ -124,5 +124,5 @@ export default Ember.Mixin.create({
 
     }
 
-  }.on('init')
+  })
 });

--- a/addon/utils/is-gesture.js
+++ b/addon/utils/is-gesture.js
@@ -3,7 +3,7 @@ import hammerEvents from "./hammer-events";
 
 var Gestures = {};
 
-var gestureGroups = Ember.keys(hammerEvents), i;
+var gestureGroups = Object.keys(hammerEvents), i;
 for (i = 0; i < gestureGroups.length; i++) {
   Ember.merge(Gestures, hammerEvents[gestureGroups[i]]);
 }


### PR DESCRIPTION
This is a simple update to get this working with ember-cli 1.13.1 and remove a deprecation warning too